### PR TITLE
- InitializeModules added (InitializeShell)

### DIFF
--- a/ESAPIX.Bootstrapper/BootstrapperBase.cs
+++ b/ESAPIX.Bootstrapper/BootstrapperBase.cs
@@ -61,7 +61,7 @@ namespace ESAPIX.Bootstrapper
                 Splash.Closing += (ob, args)=> { mre.Set(); } ;
                 await Task.Run(() => { mre.WaitOne(); });
             }
-
+            InitializeModules();
             shell.ShowDialog();
             shell.ContentRendered -= shell_ContentRendered;
         }


### PR DESCRIPTION
Workaround: If the main WPF view/shell contains PRISM.Regions and PRISM.Modules, we need to initialize the the Modules. (Unless, the PRISM.Modules cannot be displayed)
